### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v2
+        with:
+          version: '9'
+          run_install: false
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Lint
+        run: pnpm lint
+      - name: Test
+        run: pnpm test
+        env:
+          POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
+          AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
+          # Add any other environment variables required by your app

--- a/README.md
+++ b/README.md
@@ -59,3 +59,13 @@ pnpm dev
 ```
 
 Your app template should now be running on [localhost:3000](http://localhost:3000/).
+
+## Continuous Integration
+
+This repository includes a GitHub Actions workflow that installs dependencies, lints the code, and runs the Playwright test suite on every push or pull request to the `main` branch. To enable the workflow:
+
+1. Open your GitHub repository and go to **Settings → Secrets and variables → Actions**.
+2. Add all environment variables required by your app (for example `POSTGRES_URL` and `AUTH_SECRET`) as secrets.
+3. Commit and push the repository. GitHub will automatically execute the workflow defined at `.github/workflows/test.yml`.
+
+You can view the status of each run in the **Actions** tab of your repository.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint and run tests
- document how to use the workflow

## Testing
- `pnpm lint` *(fails: could not download pnpm)*