### PR TITLE
Add Playwright test automation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_DB: chatbot
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      POSTGRES_URL: postgres://postgres:postgres@localhost:5432/chatbot
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec drizzle-kit push
+      - run: pnpm run test

--- a/README.md
+++ b/README.md
@@ -59,3 +59,15 @@ pnpm dev
 ```
 
 Your app template should now be running on [localhost:3000](http://localhost:3000/).
+
+## Testing
+
+Playwright tests are included in the `tests` directory. Run them locally with:
+
+```bash
+pnpm install
+pnpm run db:migrate
+pnpm run test
+```
+
+Tests are also executed automatically on every push and pull request using [GitHub Actions](https://docs.github.com/en/actions).


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Playwright tests
- document how to run tests locally and mention workflow

## Testing
- `pnpm run test` *(fails: Error when performing the request to https://registry.npmjs.org/...)*