### PR TITLE
Fix Playwright CI step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,5 +34,6 @@ jobs:
           node-version: 20
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps
       - run: pnpm exec drizzle-kit push
       - run: pnpm run test


### PR DESCRIPTION
## Summary
- install Playwright browsers in CI before running tests

## Testing
- `pnpm exec playwright install --with-deps` *(fails: connect EHOSTUNREACH)*
- `pnpm run test` *(fails: connect EHOSTUNREACH)*