### PR TITLE
Add OpenAI provider option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,12 @@ AUTH_SECRET=your_auth_secret
 # Set to 'false' to disable login requirement
 AUTH_REQUIRED=true
 
+# AI model provider (xai or openai)
+AI_PROVIDER=xai
+
 # API keys
 XAI_API_KEY=your_xai_api_key
+OPENAI_API_KEY=your_openai_api_key
 GROQ_API_KEY=your_groq_api_key
 
 # Vercel Blob token

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 ## Model Providers
 
-This template ships with [xAI](https://x.ai) `grok-2-1212` as the default chat model. However, with the [AI SDK](https://sdk.vercel.ai/docs), you can switch LLM providers to [OpenAI](https://openai.com), [Anthropic](https://anthropic.com), [Cohere](https://cohere.com/), and [many more](https://sdk.vercel.ai/providers/ai-sdk-providers) with just a few lines of code.
+This template ships with [xAI](https://x.ai) `grok-2-1212` as the default chat model. To use OpenAI instead, set `AI_PROVIDER=openai` and provide your `OPENAI_API_KEY`. With the [AI SDK](https://sdk.vercel.ai/docs), you can also switch LLM providers to [Anthropic](https://anthropic.com), [Cohere](https://cohere.com/), and [many more](https://sdk.vercel.ai/providers/ai-sdk-providers) with just a few lines of code.
 
 
 ## Running locally

--- a/docs/01-quick-start.md
+++ b/docs/01-quick-start.md
@@ -12,6 +12,8 @@ Deploying to [Vercel](https://vercel.com) is the quickest way to get started wit
   - [xAI](https://console.x.ai/)
   - [OpenAI](https://platform.openai.com/account/api-keys)
   - [Fireworks](https://fireworks.ai/account/api-keys)
+  
+Set `AI_PROVIDER=openai` in your environment to use OpenAI instead of the default xAI model.
 
 ### Deploy to Vercel
 

--- a/docs/02-update-models.md
+++ b/docs/02-update-models.md
@@ -1,6 +1,6 @@
 # Update Models
 
-The chatbot template ships with [xAI](https://sdk.vercel.ai/providers/ai-sdk-providers/xai) as the default model provider. Since the template is powered by the [AI SDK](https://sdk.vercel.ai), which supports [multiple providers](https://sdk.vercel.ai/providers/ai-sdk-providers) out of the box, you can easily switch to another provider of your choice.
+The chatbot template ships with [xAI](https://sdk.vercel.ai/providers/ai-sdk-providers/xai) as the default model provider. Since the template is powered by the [AI SDK](https://sdk.vercel.ai), which supports [multiple providers](https://sdk.vercel.ai/providers/ai-sdk-providers) out of the box, you can easily switch to another provider of your choice. Set `AI_PROVIDER=openai` and provide your `OPENAI_API_KEY` if you prefer OpenAI.
 
 To update the models, you will need to update the custom provider called `myProvider` at `/lib/ai/models.ts` shown below.
 
@@ -28,7 +28,7 @@ export const myProvider = customProvider({
 
 You can replace the models with any other provider of your choice. You will need to install the provider library and switch the models accordingly.
 
-For example, if you want to use Anthropic's `claude-3-5-sonnet` model for `chat-model`, you can replace the `xai` model with the `anthropic` model as shown below.
+For example, if you want to use Anthropic's `claude-3-5-sonnet` model for `chat-model`, you can replace the `xai` model (or `openai` if selected) with the `anthropic` model as shown below.
 
 ```ts
 import { customProvider } from "ai";
@@ -38,7 +38,7 @@ import { anthropic } from "@ai-sdk/anthropic";
 
 export const myProvider = customProvider({
   languageModels: {
-    "chat-model": anthropic("claude-3-5-sonnet"), // Replace xai with anthropic
+    "chat-model": anthropic("claude-3-5-sonnet"), // Replace xai/openai with anthropic
     "chat-model-reasoning": wrapLanguageModel({
       model: groq("deepseek-r1-distill-llama-70b"),
       middleware: extractReasoningMiddleware({ tagName: "think" }),

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -4,6 +4,7 @@ import {
   wrapLanguageModel,
 } from 'ai';
 import { groq } from '@ai-sdk/groq';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { xai } from '@ai-sdk/xai';
 import { isTestEnvironment } from '../constants';
 import {
@@ -12,6 +13,15 @@ import {
   reasoningModel,
   titleModel,
 } from './models.test';
+
+const openaiProvider = createOpenAICompatible({
+  name: 'openai',
+  baseURL: 'https://api.openai.com/v1',
+  apiKey: process.env.OPENAI_API_KEY ?? '',
+});
+
+const providerName = process.env.AI_PROVIDER || 'xai';
+const isOpenAI = providerName === 'openai';
 
 export const myProvider = isTestEnvironment
   ? customProvider({
@@ -24,15 +34,23 @@ export const myProvider = isTestEnvironment
     })
   : customProvider({
       languageModels: {
-        'chat-model': xai('grok-2-1212'),
+        'chat-model': isOpenAI
+          ? openaiProvider.chatModel('gpt-4o')
+          : xai('grok-2-1212'),
         'chat-model-reasoning': wrapLanguageModel({
           model: groq('deepseek-r1-distill-llama-70b'),
           middleware: extractReasoningMiddleware({ tagName: 'think' }),
         }),
-        'title-model': xai('grok-2-1212'),
-        'artifact-model': xai('grok-2-1212'),
+        'title-model': isOpenAI
+          ? openaiProvider.chatModel('gpt-4o')
+          : xai('grok-2-1212'),
+        'artifact-model': isOpenAI
+          ? openaiProvider.chatModel('gpt-4o')
+          : xai('grok-2-1212'),
       },
       imageModels: {
-        'small-model': xai.image('grok-2-image'),
+        'small-model': isOpenAI
+          ? openaiProvider.imageModel('dall-e-3')
+          : xai.image('grok-2-image'),
       },
     });


### PR DESCRIPTION
## Summary
- support both xAI and OpenAI providers via `AI_PROVIDER`
- document the new variable in README and docs
- keep Fireworks instructions

## Testing
- `pnpm lint` *(fails: connect EHOSTUNREACH)*
- `pnpm test` *(fails: connect EHOSTUNREACH)*