### PR TITLE
Allow unsafe eval for dev CSP

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,12 @@
 import type { NextConfig } from 'next';
 
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: "script-src 'self' 'unsafe-eval';",
+  },
+];
+
 const nextConfig: NextConfig = {
   experimental: {
     ppr: true,
@@ -10,6 +17,18 @@ const nextConfig: NextConfig = {
         hostname: 'avatar.vercel.sh',
       },
     ],
+  },
+  async headers() {
+    if (process.env.NODE_ENV === 'development') {
+      return [
+        {
+          source: '/:path*',
+          headers: securityHeaders,
+        },
+      ];
+    }
+
+    return [];
   },
 };
 


### PR DESCRIPTION
## Summary
- configure security headers for dev env in Next.js config

## Testing
- `pnpm exec biome format next.config.ts --write` *(fails: unable to download pnpm)*
- `pnpm run test` *(fails: unable to download pnpm)*