### PR TITLE
Allow jsDelivr script in CSP

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from 'next';
 
 const ContentSecurityPolicy = `
   default-src 'self';
-  script-src 'self' 'unsafe-eval' 'unsafe-inline';
+  script-src 'self' 'unsafe-eval' 'unsafe-inline' https://cdn.jsdelivr.net;
   style-src 'self' 'unsafe-inline';
   img-src * blob: data:;
   connect-src *;


### PR DESCRIPTION
## Summary
- permit the jsDelivr domain in the `script-src` directive so external scripts load

## Testing
- `pnpm run test` *(fails: connect ENOTFOUND due to missing network)*