### PR TITLE
Improve chat error reporting

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -174,7 +174,11 @@ export async function POST(request: Request) {
           sendReasoning: true,
         });
       },
-      onError: () => {
+      onError: (error: unknown) => {
+        console.error('[POST /api/chat] streaming error:', error);
+        if (error instanceof Error && error.message) {
+          return error.message;
+        }
         return 'Oops, an error occured!';
       },
     });


### PR DESCRIPTION
## Summary
- surface the actual server error message on chat API failure

## Testing
- `pnpm test` *(fails: EHOSTUNREACH)*