### PR TITLE
Fix null session check on chat onFinish

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -127,7 +127,7 @@ export async function POST(request: Request) {
             }),
           },
           onFinish: async ({ response }) => {
-            if (session.user?.id) {
+            if (session?.user?.id) {
               try {
                 const assistantId = getTrailingMessageId({
                   messages: response.messages.filter(


### PR DESCRIPTION
## Summary
- avoid runtime error when session is null in chat API

## Testing
- `pnpm lint` *(fails: unable to fetch pnpm)*