### PR TITLE
Restore provider model selection

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -107,7 +107,7 @@ export async function POST(request: Request) {
           messages,
           maxSteps: 5,
           experimental_activeTools:
-            selectedChatModel === '4.1'
+            selectedChatModel === 'chat-model-reasoning'
               ? []
               : [
                   'getWeather',

--- a/lib/ai/models.ts
+++ b/lib/ai/models.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_CHAT_MODEL: string = '4o';
+export const DEFAULT_CHAT_MODEL: string = 'chat-model';
 
 interface ChatModel {
   id: string;
@@ -7,9 +7,14 @@ interface ChatModel {
 }
 
 export const chatModels: Array<ChatModel> = [
-  { id: 'xai', name: 'xai', description: 'xai' },
-  { id: '4o', name: '4o', description: 'gpt-4o' },
-  { id: '4.1', name: '4.1', description: 'gpt-4.1' },
-  { id: '4.1-mini', name: '4.1-mini', description: 'gpt-4.1-mini' },
-  { id: '4.1-nano', name: '4.1-nano', description: 'gpt-4.1-nano' },
+  {
+    id: 'chat-model',
+    name: 'Chat model',
+    description: 'Primary model for all-purpose chat',
+  },
+  {
+    id: 'chat-model-reasoning',
+    name: 'Reasoning model',
+    description: 'Uses advanced reasoning',
+  },
 ];

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -1,32 +1,51 @@
-import { customProvider } from 'ai';
+import {
+  customProvider,
+  extractReasoningMiddleware,
+  wrapLanguageModel,
+} from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { xai } from '@ai-sdk/xai';
 import { isTestEnvironment } from '../constants';
 import {
   artifactModel,
   chatModel,
+  reasoningModel,
   titleModel,
 } from './models.test';
+
+const providerName = process.env.AI_PROVIDER || 'xai';
+const isOpenAI = providerName === 'openai';
 
 export const myProvider = isTestEnvironment
   ? customProvider({
       languageModels: {
-        xai: chatModel,
-        '4o': chatModel,
-        '4.1': chatModel,
-        '4.1-mini': titleModel,
-        '4.1-nano': artifactModel,
+        'chat-model': chatModel,
+        'chat-model-reasoning': reasoningModel,
+        'title-model': titleModel,
+        'artifact-model': artifactModel,
       },
     })
   : customProvider({
       languageModels: {
-        xai: xai('grok-2-1212'),
-        '4o': openai.chat('gpt-4o'),
-        '4.1': openai.chat('gpt-4.1'),
-        '4.1-mini': openai.chat('gpt-4.1-mini'),
-        '4.1-nano': openai.chat('gpt-4.1-nano'),
+        'chat-model': isOpenAI
+          ? openai.chat('gpt-4o')
+          : xai('grok-2-vision-1212'),
+        'chat-model-reasoning': isOpenAI
+          ? openai.chat('gpt-4.1')
+          : wrapLanguageModel({
+              model: xai('grok-3-mini-beta'),
+              middleware: extractReasoningMiddleware({ tagName: 'think' }),
+            }),
+        'title-model': isOpenAI
+          ? openai.chat('gpt-4.1-mini')
+          : xai('grok-2-1212'),
+        'artifact-model': isOpenAI
+          ? openai.chat('gpt-4.1-nano')
+          : xai('grok-2-1212'),
       },
       imageModels: {
-        'small-model': openai.image('dall-e-3'),
+        'small-model': isOpenAI
+          ? openai.image('dall-e-3')
+          : xai.image('grok-2-image'),
       },
     });

--- a/tests/reasoning.setup.ts
+++ b/tests/reasoning.setup.ts
@@ -11,9 +11,9 @@ setup('switch to reasoning model', async ({ page }) => {
   const chatPage = new ChatPage(page);
   await chatPage.createNewChat();
 
-  await chatPage.chooseModelFromSelector('4.1');
+  await chatPage.chooseModelFromSelector('chat-model-reasoning');
 
-  await expect(chatPage.getSelectedModel()).resolves.toEqual('4.1');
+  await expect(chatPage.getSelectedModel()).resolves.toEqual('Reasoning model');
 
   await page.waitForTimeout(1000);
   await page.context().storageState({ path: reasoningFile });


### PR DESCRIPTION
## Summary
- revert to old chat model list and reasoning model alias
- use `AI_PROVIDER` env var to switch between xAI and OpenAI models
- update chat API and tests for reasoning model

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org)*