### PR TITLE
Add xAi and GPT-4 model options

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -107,7 +107,7 @@ export async function POST(request: Request) {
           messages,
           maxSteps: 5,
           experimental_activeTools:
-            selectedChatModel === 'chat-model-reasoning'
+            selectedChatModel === '4.1'
               ? []
               : [
                   'getWeather',

--- a/lib/ai/models.ts
+++ b/lib/ai/models.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_CHAT_MODEL: string = 'chat-model';
+export const DEFAULT_CHAT_MODEL: string = 'xai';
 
 interface ChatModel {
   id: string;
@@ -8,13 +8,28 @@ interface ChatModel {
 
 export const chatModels: Array<ChatModel> = [
   {
-    id: 'chat-model',
-    name: 'Chat model',
-    description: 'Primary model for all-purpose chat',
+    id: 'xai',
+    name: 'xAi',
+    description: 'Use the default xAi Grok model',
   },
   {
-    id: 'chat-model-reasoning',
-    name: 'Reasoning model',
-    description: 'Uses advanced reasoning',
+    id: '4o',
+    name: '4o',
+    description: 'Use OpenAI gpt-4o',
+  },
+  {
+    id: '4.1',
+    name: '4.1',
+    description: 'Use OpenAI gpt-4.1 reasoning model',
+  },
+  {
+    id: '4.1-mini',
+    name: '4.1-mini',
+    description: 'Use OpenAI gpt-4.1-mini',
+  },
+  {
+    id: '4.1-nano',
+    name: '4.1-nano',
+    description: 'Use OpenAI gpt-4.1-nano',
   },
 ];

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -1,8 +1,4 @@
-import {
-  customProvider,
-  extractReasoningMiddleware,
-  wrapLanguageModel,
-} from 'ai';
+import { customProvider } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { xai } from '@ai-sdk/xai';
 import { isTestEnvironment } from '../constants';
@@ -13,39 +9,31 @@ import {
   titleModel,
 } from './models.test';
 
-const providerName = process.env.AI_PROVIDER || 'xai';
-const isOpenAI = providerName === 'openai';
+
 
 export const myProvider = isTestEnvironment
   ? customProvider({
       languageModels: {
-        'chat-model': chatModel,
-        'chat-model-reasoning': reasoningModel,
+        xai: chatModel,
+        '4o': chatModel,
+        '4.1': reasoningModel,
+        '4.1-mini': chatModel,
+        '4.1-nano': chatModel,
         'title-model': titleModel,
         'artifact-model': artifactModel,
       },
     })
   : customProvider({
       languageModels: {
-        'chat-model': isOpenAI
-          ? openai.chat('gpt-4o')
-          : xai('grok-2-vision-1212'),
-        'chat-model-reasoning': isOpenAI
-          ? openai.chat('gpt-4.1')
-          : wrapLanguageModel({
-              model: xai('grok-3-mini-beta'),
-              middleware: extractReasoningMiddleware({ tagName: 'think' }),
-            }),
-        'title-model': isOpenAI
-          ? openai.chat('gpt-4.1-mini')
-          : xai('grok-2-1212'),
-        'artifact-model': isOpenAI
-          ? openai.chat('gpt-4.1-nano')
-          : xai('grok-2-1212'),
+        xai: xai('grok-2-vision-1212'),
+        '4o': openai.chat('gpt-4o'),
+        '4.1': openai.chat('gpt-4.1'),
+        '4.1-mini': openai.chat('gpt-4.1-mini'),
+        '4.1-nano': openai.chat('gpt-4.1-nano'),
+        'title-model': xai('grok-2-1212'),
+        'artifact-model': xai('grok-2-1212'),
       },
       imageModels: {
-        'small-model': isOpenAI
-          ? openai.image('dall-e-3')
-          : xai.image('grok-2-image'),
+        'small-model': xai.image('grok-2-image'),
       },
     });

--- a/tests/reasoning.setup.ts
+++ b/tests/reasoning.setup.ts
@@ -11,9 +11,9 @@ setup('switch to reasoning model', async ({ page }) => {
   const chatPage = new ChatPage(page);
   await chatPage.createNewChat();
 
-  await chatPage.chooseModelFromSelector('chat-model-reasoning');
+  await chatPage.chooseModelFromSelector('4.1');
 
-  await expect(chatPage.getSelectedModel()).resolves.toEqual('Reasoning model');
+  await expect(chatPage.getSelectedModel()).resolves.toEqual('4.1');
 
   await page.waitForTimeout(1000);
   await page.context().storageState({ path: reasoningFile });


### PR DESCRIPTION
## Summary
- expand model selector to offer xAi and several GPT‑4 variants
- map new model ids to the proper providers
- update chat endpoint logic for new model ids
- adjust reasoning setup for tests

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.3.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.3.tgz)*