### PR TITLE
Enable local chat history for anonymous users

### DIFF
--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -1,4 +1,5 @@
 import { cookies } from 'next/headers';
+import { auth } from '../(auth)/auth';
 
 import { Chat } from '@/components/chat';
 import { DEFAULT_CHAT_MODEL } from '@/lib/ai/models';
@@ -8,8 +9,9 @@ import { DataStreamHandler } from '@/components/data-stream-handler';
 export default async function Page() {
   const id = generateUUID();
 
-  const cookieStore = await cookies();
+  const [session, cookieStore] = await Promise.all([auth(), cookies()]);
   const modelIdFromCookie = cookieStore.get('chat-model');
+  const isAuthenticated = !!session?.user;
 
   if (!modelIdFromCookie) {
     return (
@@ -20,6 +22,7 @@ export default async function Page() {
           initialMessages={[]}
           selectedChatModel={DEFAULT_CHAT_MODEL}
           isReadonly={false}
+          isAuthenticated={isAuthenticated}
         />
         <DataStreamHandler id={id} />
       </>
@@ -34,6 +37,7 @@ export default async function Page() {
         initialMessages={[]}
         selectedChatModel={modelIdFromCookie.value}
         isReadonly={false}
+        isAuthenticated={isAuthenticated}
       />
       <DataStreamHandler id={id} />
     </>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -45,6 +45,18 @@ export function getLocalStorage(key: string) {
   return [];
 }
 
+export function setLocalStorage(key: string, value: unknown) {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(key, JSON.stringify(value));
+  }
+}
+
+export function removeLocalStorage(key: string) {
+  if (typeof window !== 'undefined') {
+    localStorage.removeItem(key);
+  }
+}
+
 export function generateUUID(): string {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
     const r = (Math.random() * 16) | 0;


### PR DESCRIPTION
## Summary
- add local storage helpers
- store messages locally when not authenticated
- load/save chat history from local storage in SidebarHistory
- pass auth status to Chat component and pages

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/...)*
- `pnpm run db:migrate` *(fails: Error when performing the request to https://registry.npmjs.org/...)*
- `pnpm run test` *(fails: Error when performing the request to https://registry.npmjs.org/...)*