### PR TITLE
Allow optional authentication in API routes

### DIFF
--- a/app/(chat)/api/document/route.ts
+++ b/app/(chat)/api/document/route.ts
@@ -15,8 +15,9 @@ export async function GET(request: Request) {
   }
 
   const session = await auth();
+  const requireAuth = process.env.AUTH_REQUIRED !== 'false';
 
-  if (!session || !session.user) {
+  if (requireAuth && (!session || !session.user)) {
     return new Response('Unauthorized', { status: 401 });
   }
 
@@ -28,7 +29,7 @@ export async function GET(request: Request) {
     return new Response('Not Found', { status: 404 });
   }
 
-  if (document.userId !== session.user.id) {
+  if (session?.user?.id && document.userId !== session.user.id) {
     return new Response('Unauthorized', { status: 401 });
   }
 
@@ -44,8 +45,9 @@ export async function POST(request: Request) {
   }
 
   const session = await auth();
+  const requireAuth = process.env.AUTH_REQUIRED !== 'false';
 
-  if (!session) {
+  if (requireAuth && !session) {
     return new Response('Unauthorized', { status: 401 });
   }
 
@@ -82,8 +84,9 @@ export async function PATCH(request: Request) {
   }
 
   const session = await auth();
+  const requireAuth = process.env.AUTH_REQUIRED !== 'false';
 
-  if (!session || !session.user) {
+  if (requireAuth && (!session || !session.user)) {
     return new Response('Unauthorized', { status: 401 });
   }
 
@@ -91,7 +94,7 @@ export async function PATCH(request: Request) {
 
   const [document] = documents;
 
-  if (document.userId !== session.user.id) {
+  if (session?.user?.id && document.userId !== session.user.id) {
     return new Response('Unauthorized', { status: 401 });
   }
 

--- a/app/(chat)/api/files/upload/route.ts
+++ b/app/(chat)/api/files/upload/route.ts
@@ -19,8 +19,9 @@ const FileSchema = z.object({
 
 export async function POST(request: Request) {
   const session = await auth();
+  const requireAuth = process.env.AUTH_REQUIRED !== 'false';
 
-  if (!session) {
+  if (requireAuth && !session) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/app/(chat)/api/history/route.ts
+++ b/app/(chat)/api/history/route.ts
@@ -3,9 +3,14 @@ import { getChatsByUserId } from '@/lib/db/queries';
 
 export async function GET() {
   const session = await auth();
+  const requireAuth = process.env.AUTH_REQUIRED !== 'false';
 
-  if (!session || !session.user) {
+  if (requireAuth && (!session || !session.user)) {
     return Response.json('Unauthorized!', { status: 401 });
+  }
+
+  if (!session?.user?.id) {
+    return Response.json([]);
   }
 
   // biome-ignore lint: Forbidden non-null assertion.

--- a/app/(chat)/api/suggestions/route.ts
+++ b/app/(chat)/api/suggestions/route.ts
@@ -10,8 +10,9 @@ export async function GET(request: Request) {
   }
 
   const session = await auth();
+  const requireAuth = process.env.AUTH_REQUIRED !== 'false';
 
-  if (!session || !session.user) {
+  if (requireAuth && (!session || !session.user)) {
     return new Response('Unauthorized', { status: 401 });
   }
 
@@ -25,7 +26,7 @@ export async function GET(request: Request) {
     return Response.json([], { status: 200 });
   }
 
-  if (suggestion.userId !== session.user.id) {
+  if (session?.user?.id && suggestion.userId !== session.user.id) {
     return new Response('Unauthorized', { status: 401 });
   }
 

--- a/app/(chat)/api/vote/route.ts
+++ b/app/(chat)/api/vote/route.ts
@@ -10,8 +10,9 @@ export async function GET(request: Request) {
   }
 
   const session = await auth();
+  const requireAuth = process.env.AUTH_REQUIRED !== 'false';
 
-  if (!session || !session.user || !session.user.email) {
+  if (requireAuth && (!session || !session.user || !session.user.email)) {
     return new Response('Unauthorized', { status: 401 });
   }
 
@@ -21,7 +22,7 @@ export async function GET(request: Request) {
     return new Response('Chat not found', { status: 404 });
   }
 
-  if (chat.userId !== session.user.id) {
+  if (session?.user?.id && chat.userId !== session.user.id) {
     return new Response('Unauthorized', { status: 401 });
   }
 
@@ -43,8 +44,9 @@ export async function PATCH(request: Request) {
   }
 
   const session = await auth();
+  const requireAuth = process.env.AUTH_REQUIRED !== 'false';
 
-  if (!session || !session.user || !session.user.email) {
+  if (requireAuth && (!session || !session.user || !session.user.email)) {
     return new Response('Unauthorized', { status: 401 });
   }
 
@@ -54,7 +56,7 @@ export async function PATCH(request: Request) {
     return new Response('Chat not found', { status: 404 });
   }
 
-  if (chat.userId !== session.user.id) {
+  if (session?.user?.id && chat.userId !== session.user.id) {
     return new Response('Unauthorized', { status: 401 });
   }
 


### PR DESCRIPTION
## Summary
- respect `AUTH_REQUIRED=false` in various chat-related API routes
- skip session checks when auth is not required

## Testing
- `pnpm lint` *(fails: connect EHOSTUNREACH)*
- `pnpm test` *(fails: connect EHOSTUNREACH)*