### PR TITLE
Avoid 404 requests when unauthenticated

### DIFF
--- a/components/artifact.tsx
+++ b/components/artifact.tsx
@@ -66,6 +66,7 @@ function PureArtifact({
   reload,
   votes,
   isReadonly,
+  isAuthenticated,
 }: {
   chatId: string;
   input: string;
@@ -81,6 +82,7 @@ function PureArtifact({
   handleSubmit: UseChatHelpers['handleSubmit'];
   reload: UseChatHelpers['reload'];
   isReadonly: boolean;
+  isAuthenticated: boolean;
 }) {
   const { artifact, setArtifact, metadata, setMetadata } = useArtifact();
 
@@ -89,7 +91,9 @@ function PureArtifact({
     isLoading: isDocumentsFetching,
     mutate: mutateDocuments,
   } = useSWR<Array<Document>>(
-    artifact.documentId !== 'init' && artifact.status !== 'streaming'
+    isAuthenticated &&
+      artifact.documentId !== 'init' &&
+      artifact.status !== 'streaming'
       ? `/api/document?id=${artifact.documentId}`
       : null,
     fetcher,
@@ -126,6 +130,8 @@ function PureArtifact({
   const handleContentChange = useCallback(
     (updatedContent: string) => {
       if (!artifact) return;
+
+      if (!isAuthenticated) return;
 
       mutate<Array<Document>>(
         `/api/document?id=${artifact.documentId}`,

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -69,7 +69,7 @@ export function Chat({
   });
 
   const { data: votes } = useSWR<Array<Vote>>(
-    messages.length >= 2 ? `/api/vote?chatId=${id}` : null,
+    isAuthenticated && messages.length >= 2 ? `/api/vote?chatId=${id}` : null,
     fetcher,
   );
 
@@ -155,6 +155,7 @@ export function Chat({
         reload={reload}
         votes={votes}
         isReadonly={isReadonly}
+        isAuthenticated={isAuthenticated}
       />
     </>
   );


### PR DESCRIPTION
## Summary
- avoid fetching votes unless logged in
- avoid fetching or saving document data unless logged in

## Testing
- `pnpm run lint` *(fails: Error: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.3.tgz)*