### PR TITLE
Enable document saving when auth disabled

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ AUTH_SECRET=your_auth_secret
 
 # Set to 'false' to disable login requirement
 AUTH_REQUIRED=true
+# When AUTH_REQUIRED is 'false', documents will be stored using this user id
+ANON_USER_ID=
 
 # AI model provider (xai or openai)
 AI_PROVIDER=xai

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This template ships with [xAI](https://x.ai) `grok-2-1212` as the default chat m
 ## Running locally
 
 You will need to use the environment variables [defined in `.env.example`](.env.example) to run Next.js AI Chatbot. It's recommended you use [Vercel Environment Variables](https://vercel.com/docs/projects/environment-variables) for this, but a `.env` file is all that is necessary. The `AUTH_REQUIRED` variable controls whether users must sign in (`true` by default; set to `false` to make login optional).
+When authentication is optional, set `ANON_USER_ID` to the ID of a user record that will own newly created documents.
 
 > Note: You should not commit your `.env` file or it will expose secrets that will allow others to control access to your various AI and authentication provider accounts.
 

--- a/app/(chat)/api/document/route.ts
+++ b/app/(chat)/api/document/route.ts
@@ -69,7 +69,19 @@ export async function POST(request: Request) {
 
     return Response.json(document, { status: 200 });
   }
-  
+
+  if (!requireAuth && process.env.ANON_USER_ID) {
+    const document = await saveDocument({
+      id,
+      content,
+      title,
+      kind,
+      userId: process.env.ANON_USER_ID,
+    });
+
+    return Response.json(document, { status: 200 });
+  }
+
   if (!requireAuth) {
     return Response.json({ skipped: true }, { status: 200 });
   }

--- a/lib/artifacts/server.ts
+++ b/lib/artifacts/server.ts
@@ -59,6 +59,14 @@ export function createDocumentHandler<T extends ArtifactKind>(config: {
           kind: config.kind,
           userId: args.session.user.id,
         });
+      } else if (process.env.AUTH_REQUIRED === 'false' && process.env.ANON_USER_ID) {
+        await saveDocument({
+          id: args.id,
+          title: args.title,
+          content: draftContent,
+          kind: config.kind,
+          userId: process.env.ANON_USER_ID,
+        });
       }
 
       return;
@@ -78,6 +86,14 @@ export function createDocumentHandler<T extends ArtifactKind>(config: {
           content: draftContent,
           kind: config.kind,
           userId: args.session.user.id,
+        });
+      } else if (process.env.AUTH_REQUIRED === 'false' && process.env.ANON_USER_ID) {
+        await saveDocument({
+          id: args.document.id,
+          title: args.document.title,
+          content: draftContent,
+          kind: config.kind,
+          userId: process.env.ANON_USER_ID,
         });
       }
 


### PR DESCRIPTION
## Summary
- support anonymous document storage when `AUTH_REQUIRED=false`
- add `ANON_USER_ID` env variable
- note new variable in README

## Testing
- `pnpm lint` *(fails: Connect Timeout Error)*
- `pnpm test` *(fails: EHOSTUNREACH)*
